### PR TITLE
Dockerfile for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN go build -v -o smart_exporter
 
 FROM alpine:3.13
 RUN apk add --no-cache smartmontools
-COPY --from=builder /proj/smart_exporter /
+COPY --from=builder /app/smart_exporter /
 CMD ["/smart_exporter"]
 EXPOSE 9649

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang AS builder
+ENV CGO_ENABLED=0
+WORKDIR /proj
+ADD . /proj
+RUN go build -v -o smart_exporter
+
+FROM alpine
+RUN apk add --no-cache ca-certificates smartmontools
+COPY --from=builder /proj/smart_exporter /
+CMD ["/smart_exporter", "-listen-addr", ":8000"]
+EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang AS builder
+FROM golang:1.16 AS builder
 ENV CGO_ENABLED=0
-WORKDIR /proj
-ADD . /proj
+WORKDIR /app
+COPY . /app
 RUN go build -v -o smart_exporter
 
-FROM alpine
-RUN apk add --no-cache ca-certificates smartmontools
+FROM alpine:3.13
+RUN apk add --no-cache smartmontools
 COPY --from=builder /proj/smart_exporter /
-CMD ["/smart_exporter", "-listen-addr", ":8000"]
-EXPOSE 8000
+CMD ["/smart_exporter"]
+EXPOSE 9649

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Release](https://img.shields.io/github/release/alexdzyoba/smart_exporter.svg?style=flat-square)](https://github.com/alexdzyoba/smart_exporter/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build status](https://github.com/alexdzyoba/smart_exporter/workflows/Build/badge.svg)](https://github.com/alexdzyoba/smart_exporter/actions)
+[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/ontrif/smart_exporter)](https://hub.docker.com/r/ontrif/smart_exporter)
 
 Prometheus exporter for critical S.M.A.R.T. metrics. It works by parsing
 smartctl output for every device. Parsing is performed independent of metrics

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ Example scrape output with metrics:
     # HELP smart_reallocated_sectors_total Number of reallocated sectors
     # TYPE smart_reallocated_sectors_total gauge
     smart_reallocated_sectors_total{device="/dev/sda"} 0
+
+Docker image can be started with command:
+```
+docker run --privileged -p 8000:8000 ontrif/smart_exporter
+```


### PR DESCRIPTION
`Dockerfile` use two stages:
- first for building from go source (`golang` image).
- second stage use `alpine` image as base for building actual image with `smart_exporter`.

Commands for manual building and running:
```
docker build -t <...name of image...> ./
docker run --privileged -p 8000:8000 <...name of image...>
```

**NOTE:** links to dockerhub repository and shields.io are provided as example. Feel free to edit or remove them.